### PR TITLE
Add `rb-readline` dev dependency

### DIFF
--- a/minimal.rb
+++ b/minimal.rb
@@ -26,6 +26,7 @@ group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'listen', '~> 3.0.5'
+  gem 'rb-readline'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'spring'


### PR DESCRIPTION

### Description
Add `rb-readline` as development dependency to fix `byebug` installation issue.

### Details
- when installing the `minimal.rb` template (on Mac OS Sierra for instance), `byebug` generated an error since it required `readline` which wasn't installed
- see `byebug` related issue https://github.com/deivid-rodriguez/byebug/issues/289