### PR TITLE
Configure application server to puma for Clever Cloud

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -233,6 +233,7 @@ RUBY
   inside 'config' do
     figaro_yml = <<-EOF
 production:
+  CC_RACKUP_SERVER: "puma"
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
   STATIC_FILES_PATH: "/public/"

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -175,6 +175,7 @@ TXT
   inside 'config' do
     figaro_yml = <<-EOF
 production:
+  CC_RACKUP_SERVER: "puma"
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
   STATIC_FILES_PATH: "/public/"


### PR DESCRIPTION
Default application server is **uWSGI** on Clever Cloud. With this configuration, we switch to **puma** 🎉 

Clever Cloud provides default values for `RAILS_MAX_THREADS` and `WEB_CONCURRENCY` based on the scaler. Of course, these values can be overwritten.