### PR TITLE
Revert puma configuration as application server for Clever Cloud

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -233,7 +233,6 @@ RUBY
   inside 'config' do
     figaro_yml = <<-EOF
 production:
-  CC_RACKUP_SERVER: "puma"
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
   STATIC_FILES_PATH: "/public/"

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -175,7 +175,6 @@ TXT
   inside 'config' do
     figaro_yml = <<-EOF
 production:
-  CC_RACKUP_SERVER: "puma"
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
   STATIC_FILES_PATH: "/public/"


### PR DESCRIPTION
Starting today, puma is the default application server for ruby apps on Clever Cloud.

Sorry for the bad timing, they released it this morning 😅 