### PR TITLE
Webconsole gem position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rails Templates
 
-Quickly generate a rails app with the default [Wagon](http://www.lewagon.org) configuration
+Quickly generate a rails app with the default [Wagon](https://www.lewagon.com) configuration
 using [Rails Templates](http://guides.rubyonrails.org/rails_application_templates.html).
 
 
@@ -9,10 +9,10 @@ using [Rails Templates](http://guides.rubyonrails.org/rails_application_template
 Get a minimal rails 5 app ready to be deployed on Heroku with Bootstrap, Simple form and debugging gems.
 
 ```bash
-gem install rails -v 5.0.5 # Maybe you already have it :)
+gem install rails -v 5.1.4 # Maybe you already have it :)
 rails new \
-  -T --database postgresql \
-  -m https://raw.githubusercontent.com/lewagon/rails-templates/master/minimal.rb \
+  --database postgresql \
+  -m https://raw.githubusercontent.com/lewagon/rails-templates/rails-51/minimal.rb \
   CHANGE_THIS_TO_YOUR_RAILS_APP_NAME
 ```
 
@@ -20,84 +20,10 @@ rails new \
 
 Same as minimal **plus** a Devise install with a generated `User` model.
 
-
 ```bash
-gem install rails -v 5.0.5 # Maybe you already have it :)
+gem install rails -v 5.1.4 # Maybe you already have it :)
 rails new \
-  -T --database postgresql \
-  -m https://raw.githubusercontent.com/lewagon/rails-templates/master/devise.rb \
+  --database postgresql \
+  -m https://raw.githubusercontent.com/lewagon/rails-templates/rails-51/devise.rb \
   CHANGE_THIS_TO_YOUR_RAILS_APP_NAME
-```
-
-# Testing
-
-These templates are generated without a `test` folder (thanks to the `-T` flag). Starting from here, you can add Minitest & Capybara with the following procedure:
-
-```ruby
-# config/application.rb
-require "rails/test_unit/railtie" # Un-comment this line
-```
-
-```bash
-# In the terminal, run:
-folders=(controllers fixtures helpers integration mailers models)
-for dir in "${folders[@]}"; do mkdir -p "test/$dir" && touch "test/$dir/.keep"; done
-cat >test/test_helper.rb <<RUBY
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
-require 'rails/test_help'
-
-class ActiveSupport::TestCase
-  fixtures :all
-end
-RUBY
-```
-
-```bash
-brew install phantomjs  # on OSX only
-                        # Linux: see https://gist.github.com/julionc/7476620
-```
-
-```ruby
-# Gemfile
-group :development, :test do
-  gem 'capybara'
-  gem 'poltergeist'
-  gem 'launchy'
-  gem 'minitest-reporters'
-  # [...]
-end
-```
-
-```bash
-bundle install
-```
-
-```ruby
-# test/test_helper.rb
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
-require 'rails/test_help'
-require 'minitest/reporters'
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
-
-class ActiveSupport::TestCase
-  fixtures :all
-end
-
-require 'capybara/rails'
-class ActionDispatch::IntegrationTest
-  include Capybara::DSL
-  def teardown
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
-    Warden.test_reset!
-  end
-end
-
-require 'capybara/poltergeist'
-Capybara.default_driver = :poltergeist
-
-include Warden::Test::Helpers
-Warden.test_mode!
 ```

--- a/devise.rb
+++ b/devise.rb
@@ -23,10 +23,13 @@ gem 'simple_form'
 gem 'uglifier'
 gem 'webpacker'
 
+group :development do
+  gem 'web-console', '>= 3.3.0'
+end
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/minimal.rb
+++ b/minimal.rb
@@ -17,10 +17,10 @@ gem 'redis'
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass'
 gem 'font-awesome-sass'
-gem 'jquery-rails'
 gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
+gem 'webpacker'
 
 group :development, :test do
   gem 'pry-byebug'
@@ -57,9 +57,7 @@ run 'unzip stylesheets.zip -d app/assets && rm stylesheets.zip && mv app/assets/
 
 run 'rm app/assets/javascripts/application.js'
 file 'app/assets/javascripts/application.js', <<-JS
-//= require jquery
-//= require jquery_ujs
-//= require bootstrap-sprockets
+//= require rails-ujs
 //= require_tree .
 JS
 
@@ -80,10 +78,12 @@ file 'app/views/layouts/application.html.erb', <<-HTML
     <%= csrf_meta_tags %>
     <%= action_cable_meta_tag %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%#= stylesheet_pack_tag 'application', media: 'all' %> <!-- Uncomment if you import CSS in app/javascript/packs/application.js -->
   </head>
   <body>
     <%= yield %>
     <%= javascript_include_tag 'application' %>
+    <%= javascript_pack_tag 'application' %>
   </body>
 </html>
 HTML
@@ -128,10 +128,38 @@ after_bundle do
 log/*.log
 tmp/**/*
 tmp/*
+!log/.keep
+!tmp/.keep
 *.swp
 .DS_Store
 public/assets
+public/packs
+public/packs-test
+node_modules
 TXT
+
+  # Webpacker / Yarn
+  ########################################
+  rake 'webpacker:install'
+  run 'rm app/javascript/packs/application.js'
+  run 'yarn add jquery bootstrap@3'
+  file 'app/javascript/packs/application.js', <<-JS
+import "bootstrap";
+JS
+
+  inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
+<<-JS
+// Bootstrap 3 has a dependency over jQuery:
+const webpack = require('webpack')
+environment.plugins.set('Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery'
+  })
+)
+
+JS
+  end
 
   # Figaro
   ########################################

--- a/minimal.rb
+++ b/minimal.rb
@@ -22,10 +22,13 @@ gem 'simple_form'
 gem 'uglifier'
 gem 'webpacker'
 
+group :development do
+  gem 'web-console', '>= 3.3.0'
+end
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'


### PR DESCRIPTION
If you try to run the test with the gem 'web-console' in the development / test gems group, Minitest will complain.
I moved it to `:development` group only.

Below, minitest message 👇 

```
Web Console is activated in the test environment. This is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it in the test environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false
```