### PR TITLE
Moving web console gem to dev group only

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -23,10 +23,13 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 
+group :development do
+  gem 'web-console', '>= 3.3.0'
+end
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -22,10 +22,13 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 
+group :development do
+  gem 'web-console', '>= 3.3.0'
+end
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/devise.rb
+++ b/devise.rb
@@ -23,10 +23,13 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 
+group :development do
+  gem 'web-console', '>= 3.3.0'
+end
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/minimal.rb
+++ b/minimal.rb
@@ -22,10 +22,13 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 
+group :development do
+  gem 'web-console', '>= 3.3.0'
+end
+
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'


### PR DESCRIPTION
Shouldn't we move the web-console gem from groupe :test, :development to :development only.
Especially if we plan to drop -T in Rails templates at some point
Testing frameworks complain is web-console is in the :test group.

(sorry, I opened and closed a lot of PR. But I got stuck with other's commit. I think I was in the git sh*tstorm 😉 )