### PR TITLE
Changed set method to prepend method in webpacker

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -212,7 +212,7 @@ JS
 <<-JS
 // Bootstrap 3 has a dependency over jQuery:
 const webpack = require('webpack')
-environment.plugins.set('Provide',
+environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',
     jQuery: 'jquery'

--- a/minimal.rb
+++ b/minimal.rb
@@ -154,7 +154,7 @@ JS
 <<-JS
 // Bootstrap 3 has a dependency over jQuery:
 const webpack = require('webpack')
-environment.plugins.set('Provide',
+environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',
     jQuery: 'jquery'


### PR DESCRIPTION
`set` method is removed from webpacker 3.3.0.
So we might want to use `prepend` instead of `set`.

Discussion in slack: https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1520242516000429
https://github.com/rails/webpacker/issues/1318
https://github.com/rails/webpacker/blob/master/CHANGELOG.md#330---2018-03-03