### PR TITLE
Add CACHE_DEPENDENCIES env variable to Clever Cloud templates

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -239,6 +239,7 @@ production:
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
   STATIC_FILES_PATH: "/public/"
+  CACHE_DEPENDENCIES: "true" # disable it when going live
 EOF
     file 'application.yml', figaro_yml, force: true
   end

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -181,6 +181,7 @@ production:
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
   STATIC_FILES_PATH: "/public/"
+  CACHE_DEPENDENCIES: "true" # disable it when going live
 EOF
     file 'application.yml', figaro_yml, force: true
   end


### PR DESCRIPTION
Prevents from reinstalling all the gems each time we deploy :grimacing: 