### PR TITLE
Use rails_command instead of rake

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -216,7 +216,7 @@ RUBY
 
   # migrate + devise views
   ########################################
-  rake 'db:migrate'
+  rails_command 'db:migrate'
   generate('devise:views')
 
   # Pages Controller

--- a/devise.rb
+++ b/devise.rb
@@ -137,7 +137,7 @@ environment generators
 after_bundle do
   # Generators: db + simple form + pages controller
   ########################################
-  rake 'db:drop db:create db:migrate'
+  rails_command 'db:drop db:create db:migrate'
   generate('simple_form:install', '--bootstrap')
   generate(:controller, 'pages', 'home', '--skip-routes', '--no-test-framework')
 
@@ -181,7 +181,7 @@ RUBY
 
   # migrate + devise views
   ########################################
-  rake 'db:migrate'
+  rails_command 'db:migrate'
   generate('devise:views')
 
   # Pages Controller


### PR DESCRIPTION
The `rails_command` is already used in the minimal templates.
Let's also use it within the devise templates.