### PR TITLE
set bootsnap version to 1.1.8

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -22,7 +22,7 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 gem 'webpacker'
-gem 'bootsnap', require: false
+gem 'bootsnap', '1.1.8', require: false
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -21,7 +21,7 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 gem 'webpacker'
-gem 'bootsnap', require: false
+gem 'bootsnap', '1.1.8', require: false
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/devise.rb
+++ b/devise.rb
@@ -22,7 +22,7 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 gem 'webpacker'
-gem 'bootsnap', require: false
+gem 'bootsnap', '1.1.8', require: false
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/minimal.rb
+++ b/minimal.rb
@@ -21,7 +21,7 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 gem 'webpacker'
-gem 'bootsnap', require: false
+gem 'bootsnap', '1.1.8', require: false
 
 group :development do
   gem 'web-console', '>= 3.3.0'


### PR DESCRIPTION
ping @db0sch

I changed bootsnap version to fix this error encounter by Jonathan Serafini: 
```
ActiveSupport::Concern::MultipleIncludedBlocks: Cannot define multiple 'included' blocks for a Concern
```

Tell me if it's seems good to you