### PR TITLE
Update clever cloud templates

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -266,10 +266,14 @@ JS
   inside 'config' do
     figaro_yml = <<-EOF
 production:
+  # rails
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
+  # clever cloud
   STATIC_FILES_PATH: "/public/"
   CACHE_DEPENDENCIES: "true" # disable it when going live
+  CC_RACKUP_SERVER: "puma"
+  PORT: "8080"
 EOF
     file 'application.yml', figaro_yml, force: true
   end

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -208,10 +208,14 @@ JS
   inside 'config' do
     figaro_yml = <<-EOF
 production:
+  # rails
   RAILS_ENV: "production"
   SECRET_KEY_BASE: "#{SecureRandom.hex(64)}"
+  # clever cloud
   STATIC_FILES_PATH: "/public/"
   CACHE_DEPENDENCIES: "true" # disable it when going live
+  CC_RACKUP_SERVER: "puma"
+  PORT: "8080"
 EOF
     file 'application.yml', figaro_yml, force: true
   end


### PR DESCRIPTION
Add default `CC_RACKUP_SERVER` and `PORT` environment variables

Long story "short": 

These variables are automatically set up by Clever Cloud **but** when we import the environment variables from the file `config/application.yml` (through the `clever env import`), it erases any existing environment variable and sets up only the ones provided by our yaml file.

So we have to provide them again...

Related issue: https://github.com/CleverCloud/clever-tools/issues/214
Outcome: they "might" implement a `--replace` option for `clever env import` command :pray: 