### PR TITLE
Add bootsnap gem if Rails is 5.2 or greater

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -7,6 +7,7 @@ file 'Gemfile', <<-RUBY
 source 'https://rubygems.org'
 ruby '#{RUBY_VERSION}'
 
+#{"gem 'bootsnap', require: false" if Rails.version >= "5.2"}
 gem 'devise'
 gem 'figaro'
 gem 'jbuilder', '~> 2.0'

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -7,6 +7,7 @@ file 'Gemfile', <<-RUBY
 source 'https://rubygems.org'
 ruby '#{RUBY_VERSION}'
 
+#{"gem 'bootsnap', require: false" if Rails.version >= "5.2"}
 gem 'figaro'
 gem 'jbuilder', '~> 2.0'
 gem 'pg', '~> 0.21'

--- a/devise.rb
+++ b/devise.rb
@@ -7,6 +7,7 @@ file 'Gemfile', <<-RUBY
 source 'https://rubygems.org'
 ruby '#{RUBY_VERSION}'
 
+#{"gem 'bootsnap', require: false" if Rails.version >= "5.2"}
 gem 'devise'
 gem 'figaro'
 gem 'jbuilder', '~> 2.0'

--- a/minimal.rb
+++ b/minimal.rb
@@ -7,6 +7,7 @@ file 'Gemfile', <<-RUBY
 source 'https://rubygems.org'
 ruby '#{RUBY_VERSION}'
 
+#{"gem 'bootsnap', require: false" if Rails.version >= "5.2"}
 gem 'figaro'
 gem 'jbuilder', '~> 2.0'
 gem 'pg', '~> 0.21'


### PR DESCRIPTION
Only for rails 5.2 as it is required by default