### PR TITLE
Use minitest for test generators

### DIFF
--- a/minimal.rb
+++ b/minimal.rb
@@ -105,7 +105,7 @@ generators = <<-RUBY
 config.generators do |generate|
       generate.assets false
       generate.helper false
-      generate.test_framework  :test_unit, fixture: false
+      generate.test_framework :minitest, spec: false, fixture: false
     end
 RUBY
 


### PR DESCRIPTION
This replaces `:test_unit` with `:minitest` to match our choice of test framework for the "Testing in Rails" lesson (https://kitt.lewagon.com/knowledge/lectures/06-Projects%2F05-Build-an-API#/0/3/2).