### PR TITLE
Remove font-awesome version from clever-cloud templates

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -17,7 +17,7 @@ gem 'redis'
 
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass', '~> 3.3'
-gem 'font-awesome-sass', '~> 5.0.9'
+gem 'font-awesome-sass'
 gem 'sassc-rails'
 gem 'simple_form'
 gem 'uglifier'

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -16,7 +16,7 @@ gem 'redis'
 
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass', '~> 3.3'
-gem 'font-awesome-sass', '~> 5.0.9'
+gem 'font-awesome-sass'
 gem 'sassc-rails'
 gem 'simple_form'
 gem 'uglifier'


### PR DESCRIPTION
In clever-cloud templates minimal and devise Gemfile :
remove font-awesome version (bug in rails new with the version : _LoadError: cannot load such file -- sass_)