### PR TITLE
Add exact version for Bootstrap js dependencies

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -232,7 +232,7 @@ RUBY
   # Webpacker / Yarn
   ########################################
   run 'rm app/javascript/packs/application.js'
-  run 'yarn add jquery bootstrap@3'
+  run 'yarn add jquery bootstrap@3.4.0'
   file 'app/javascript/packs/application.js', <<-JS
 import "bootstrap";
 JS

--- a/minimal.rb
+++ b/minimal.rb
@@ -174,7 +174,7 @@ TXT
   # Webpacker / Yarn
   ########################################
   run 'rm app/javascript/packs/application.js'
-  run 'yarn add jquery bootstrap@3'
+  run 'yarn add jquery bootstrap@3.4.0'
   file 'app/javascript/packs/application.js', <<-JS
 import "bootstrap";
 JS


### PR DESCRIPTION
During the Devise lecture, using the minimal template, Github warned me that I have a security issue with the version of Bootstrap. 
It seems that I had the right version on my computer (3.4.0), but as the version on the `package.json` was just `bootastrap@3`, github was flagging it as vulnerable.
So, i just added the exact version number found in the github release list.
https://github.com/twbs/bootstrap/releases

It removes the security alert on the repo.