### PR TITLE
FIX - Readline Problems With Ruby on OSX -

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -28,6 +28,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'rb-readline'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'listen', '~> 3.0.5'


### PR DESCRIPTION
The relevant error message and failure, issued by byebug was:

Sorry, you can't use byebug without Readline. To solve this, you need to rebuild Ruby with Readline support. If using Ubuntu, try `sudo apt-get install

For a longer-term fix we are experimenting with including the rb-readline gem in the development group of our Gemfile.