### PR TITLE
Prevent Babel from transpiling node_modules packages

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -246,11 +246,12 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+const webpack = require('webpack')
+
 // Preventing Babel from transpiling NodeModules packages
 environment.loaders.delete('nodeModules');
 
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
-const webpack = require('webpack')
 environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',

--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -246,6 +246,9 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+// Preventing Babel from transpiling NodeModules packages
+environment.loaders.delete('nodeModules');
+
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
 const webpack = require('webpack')
 environment.plugins.prepend('Provide',

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -185,6 +185,9 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+// Preventing Babel from transpiling NodeModules packages
+environment.loaders.delete('nodeModules');
+
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
 const webpack = require('webpack')
 environment.plugins.prepend('Provide',

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -185,11 +185,12 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+const webpack = require('webpack')
+
 // Preventing Babel from transpiling NodeModules packages
 environment.loaders.delete('nodeModules');
 
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
-const webpack = require('webpack')
 environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',

--- a/devise.rb
+++ b/devise.rb
@@ -211,11 +211,12 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+const webpack = require('webpack')
+
 // Preventing Babel from transpiling NodeModules packages
 environment.loaders.delete('nodeModules');
 
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
-const webpack = require('webpack')
 environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',

--- a/devise.rb
+++ b/devise.rb
@@ -211,6 +211,9 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+// Preventing Babel from transpiling NodeModules packages
+environment.loaders.delete('nodeModules');
+
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
 const webpack = require('webpack')
 environment.plugins.prepend('Provide',

--- a/minimal.rb
+++ b/minimal.rb
@@ -149,11 +149,12 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+const webpack = require('webpack')
+
 // Preventing Babel from transpiling NodeModules packages
 environment.loaders.delete('nodeModules');
 
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
-const webpack = require('webpack')
 environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',

--- a/minimal.rb
+++ b/minimal.rb
@@ -149,6 +149,9 @@ JS
 
   inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
 <<-JS
+// Preventing Babel from transpiling NodeModules packages
+environment.loaders.delete('nodeModules');
+
 // Bootstrap 4 has a dependency over jQuery & Popper.js:
 const webpack = require('webpack')
 environment.plugins.prepend('Provide',


### PR DESCRIPTION
## Changes
Add a configuration line in `config/webpack/environment.js` to remove `node_modules` folder from being processed by loaders (including `babel`)

Was causing an issue with `Mapbox` js library.

Read more here: 
Webpacker doc: https://github.com/rails/webpacker/blob/master/docs/v4-upgrade.md#excluding-node_modules-from-being-transpiled-by-babel-loader
Mapbox library issue: https://github.com/mapbox/mapbox-gl-js/issues/3422
