### PR TITLE
Change commands for gitignore

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -179,24 +179,14 @@ after_bundle do
 
   # Git ignore
   ########################################
-  run 'rm .gitignore'
-  file '.gitignore', <<-TXT
-.bundle
-.clever.json
-log/*.log
-tmp/**/*
-tmp/*
-!log/.keep
-!tmp/.keep
+  append_file '.gitignore', <<-TXT
+
+# Ignore .env file containing credentials.
+.env*
+
+# Ignore Mac and Linux file system files
 *.swp
 .DS_Store
-public/assets
-public/packs
-public/packs-test
-node_modules
-yarn-error.log
-.byebug_history
-.env*
 TXT
 
   # Devise install + user

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -155,24 +155,14 @@ after_bundle do
 
   # Git ignore
   ########################################
-  run 'rm .gitignore'
-  file '.gitignore', <<-TXT
-.bundle
-.clever.json
-log/*.log
-tmp/**/*
-tmp/*
-!log/.keep
-!tmp/.keep
+  append_file '.gitignore', <<-TXT
+
+# Ignore .env file containing credentials.
+.env*
+
+# Ignore Mac and Linux file system files
 *.swp
 .DS_Store
-public/assets
-public/packs
-public/packs-test
-node_modules
-yarn-error.log
-.byebug_history
-.env*
 TXT
 
   # Webpacker / Yarn

--- a/devise.rb
+++ b/devise.rb
@@ -146,23 +146,17 @@ after_bundle do
   # Git ignore
   ########################################
   run 'rm .gitignore'
-  file '.gitignore', <<-TXT
-.bundle
-log/*.log
-tmp/**/*
-tmp/*
-!log/.keep
-!tmp/.keep
-*.swp
-.DS_Store
-public/assets
-public/packs
-public/packs-test
-node_modules
-yarn-error.log
-.byebug_history
-.env*
-TXT
+  inject_into_file '.gitignore' do
+  <<-TXT
+
+    # Ignore .env file containing credentials.
+    .env*
+
+    # Ignore Mac and Linux file system files
+    *.swp
+    .DS_Store
+  TXT
+  end
 
   # Devise install + user
   ########################################

--- a/devise.rb
+++ b/devise.rb
@@ -145,7 +145,6 @@ after_bundle do
 
   # Git ignore
   ########################################
-  run 'rm .gitignore'
   inject_into_file '.gitignore' do
   <<-TXT
 

--- a/devise.rb
+++ b/devise.rb
@@ -145,8 +145,7 @@ after_bundle do
 
   # Git ignore
   ########################################
-  append_file '.gitignore' do
-  <<-TXT
+  append_file '.gitignore', <<-TXT
 
 # Ignore .env file containing credentials.
 .env*
@@ -154,8 +153,7 @@ after_bundle do
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
-  TXT
-  end
+TXT
 
   # Devise install + user
   ########################################

--- a/devise.rb
+++ b/devise.rb
@@ -145,15 +145,15 @@ after_bundle do
 
   # Git ignore
   ########################################
-  inject_into_file '.gitignore' do
+  append_file '.gitignore' do
   <<-TXT
 
-    # Ignore .env file containing credentials.
-    .env*
+# Ignore .env file containing credentials.
+.env*
 
-    # Ignore Mac and Linux file system files
-    *.swp
-    .DS_Store
+# Ignore Mac and Linux file system files
+*.swp
+.DS_Store
   TXT
   end
 

--- a/minimal.rb
+++ b/minimal.rb
@@ -120,23 +120,14 @@ after_bundle do
 
   # Git ignore
   ########################################
-  run 'rm .gitignore'
-  file '.gitignore', <<-TXT
-.bundle
-log/*.log
-tmp/**/*
-tmp/*
-!log/.keep
-!tmp/.keep
+  append_file '.gitignore', <<-TXT
+
+# Ignore .env file containing credentials.
+.env*
+
+# Ignore Mac and Linux file system files
 *.swp
 .DS_Store
-public/assets
-public/packs
-public/packs-test
-node_modules
-yarn-error.log
-.byebug_history
-.env*
 TXT
 
   # Webpacker / Yarn


### PR DESCRIPTION
- Rails generate a almost good enough `.gitignore` file, containing the `config/master.key` (which is the standard way now to save credentials).
- We just need to append `.env` to this file as our students use the `dotenv` strategy for credentials
- Also added some operating system related files (`DS_store`)

fixes #83 

Here is the new output:

```
# See https://help.github.com/articles/ignoring-files for more about ignoring files.
#
# If you find yourself ignoring temporary files generated by your text editor
# or operating system, you probably want to add a global ignore instead:
#   git config --global core.excludesfile '~/.gitignore_global'

# Ignore bundler config.
/.bundle

# Ignore all logfiles and tempfiles.
/log/*
/tmp/*
!/log/.keep
!/tmp/.keep

# Ignore uploaded files in development
/storage/*
!/storage/.keep

/node_modules
/yarn-error.log

/public/assets
.byebug_history

# Ignore master key for decrypting credentials and more.
/config/master.key

/public/packs
/public/packs-test
/node_modules
/yarn-error.log
yarn-debug.log*
.yarn-integrity

# Ignore .env file containing credentials.
.env*

# Ignore Mac and Linux file system files
*.swp
.DS_Store
```