### PR TITLE
Remove 'protect from forgery' for application controller

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -165,7 +165,6 @@ TXT
   run 'rm app/controllers/application_controller.rb'
   file 'app/controllers/application_controller.rb', <<-RUBY
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
   before_action :authenticate_user!
 end
 RUBY


### PR DESCRIPTION
Protect from frogery is included by default since rails 5.2
https://github.com/rails/rails/commit/ec4a836919c021c0a5cf9ebeebb4db5e02104a55

Hence, no need to include it in the application controller anymore.