### PR TITLE
Fix/rubocop yml departments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,33 +9,31 @@ AllCops:
     - 'tmp/**/*'
     - 'test/**/*'
 
-ConditionalAssignment:
+Style/ConditionalAssignment:
   Enabled: false
-StringLiterals:
+Style/StringLiterals:
   Enabled: false
-RedundantReturn:
+Style/RedundantReturn:
   Enabled: false
-Documentation:
+Style/Documentation:
   Enabled: false
-WordArray:
+Style/WordArray:
   Enabled: false
-AbcSize:
+Metrics/AbcSize:
   Enabled: false
-MutableConstant:
+Style/MutableConstant:
   Enabled: false
-SignalException:
+Style/SignalException:
   Enabled: false
-Casecmp:
+Metrics/CyclomaticComplexity:
   Enabled: false
-CyclomaticComplexity:
+Style/MissingRespondToMissing:
   Enabled: false
-MissingRespondToMissing:
-  Enabled: false
-MethodMissingSuper:
+Style/MethodMissingSuper:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
-LineLength:
+Metrics/LineLength:
   Max: 120
 Style/EmptyMethod:
   Enabled: false

--- a/devise.rb
+++ b/devise.rb
@@ -23,6 +23,7 @@ gem 'uglifier'
 gem 'webpacker'
 
 group :development do
+  gem 'rubocop'
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/minimal.rb
+++ b/minimal.rb
@@ -22,6 +22,7 @@ gem 'uglifier'
 gem 'webpacker'
 
 group :development do
+  gem 'rubocop'
   gem 'web-console', '>= 3.3.0'
 end
 


### PR DESCRIPTION
Fixes #88 
- Added cop departments to `rubocop.yml`.
- Added `rubocop` to the development group in the `Gemfile` generator.
- Removed Casecmp cop from `rubocop.yml`

#### About Casecmp
Casecmp was moved to the `rubocop-performance` gem which would need to also be added to the `Gemfile` generator and then required in the `.rubocop.yml`. I opted to just remove it instead of adding the Gem to make it work. Should I just add the gem and then require it instead?