### PR TITLE
Pin fontawesome to latest version

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -16,7 +16,7 @@ gem 'rails', '#{Rails.version}'
 gem 'redis'
 
 gem 'autoprefixer-rails'
-gem 'font-awesome-sass', '~> 5.6.1'
+gem 'font-awesome-sass', '~> 5.12.0'
 gem 'sassc-rails'
 gem 'simple_form'
 gem 'uglifier'


### PR DESCRIPTION
This avoids CORS issues when displaying icons on Heroku (icons from 5.6.1 are not displayed) 