### PR TITLE
rails-ujs available

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -183,7 +183,8 @@ after_bundle do
         new webpack.ProvidePlugin({
           $: 'jquery',
           jQuery: 'jquery',
-          Popper: ['popper.js', 'default']
+          Popper: ['popper.js', 'default'],
+          Rails: ['@rails/ujs']
         })
       );
     JS

--- a/minimal.rb
+++ b/minimal.rb
@@ -123,7 +123,8 @@ after_bundle do
         new webpack.ProvidePlugin({
           $: 'jquery',
           jQuery: 'jquery',
-          Popper: ['popper.js', 'default']
+          Popper: ['popper.js', 'default'],
+          Rails: ['@rails/ujs']
         })
       );
 


### PR DESCRIPTION
This is a suggestion for our Rails 6 template

By exposing `@rails/ujs` in `environment.js` we are able to use `Rails.fire` function without having to add or import any library

Everything is already provided by the rails new with the template