### PR TITLE
fix broken rubocop.yml file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.6
   NewCops: enable
   Exclude:
     - 'bin/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 AllCops:
+  TargetRubyVersion: 2.6
+  NewCops: enable
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'
@@ -9,33 +11,31 @@ AllCops:
     - 'tmp/**/*'
     - 'test/**/*'
 
-ConditionalAssignment:
+Style/ConditionalAssignment:
   Enabled: false
-StringLiterals:
+Style/StringLiterals:
   Enabled: false
-RedundantReturn:
+Style/RedundantReturn:
   Enabled: false
-Documentation:
+Style/Documentation:
   Enabled: false
-WordArray:
+Style/WordArray:
   Enabled: false
-AbcSize:
+Metrics/AbcSize:
   Enabled: false
-MutableConstant:
+Style/MutableConstant:
   Enabled: false
-SignalException:
+Style/SignalException:
   Enabled: false
-Casecmp:
+Metrics/CyclomaticComplexity:
   Enabled: false
-CyclomaticComplexity:
+Style/MissingRespondToMissing:
   Enabled: false
-MissingRespondToMissing:
-  Enabled: false
-MethodMissingSuper:
+Style/MethodMissingSuper:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
-LineLength:
+Layout/LineLength:
   Max: 120
 Style/EmptyMethod:
   Enabled: false


### PR DESCRIPTION
My linter wasn't working because our `rubocop.yml` file was broken. That's because the cop `Casecmp` [has been moved out of rubocop](https://github.com/rubocop-hq/rubocop/issues/7117). I removed this cop, added departments to avoid current warnings, and `NewCops: enable` option to avoid warning for new cops added after rubocop v0.80. 