### PR TITLE
Useless line

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -71,7 +71,7 @@ file 'app/views/shared/_flashes.html.erb', <<~HTML
 HTML
 
 run 'curl -L https://github.com/lewagon/awesome-navbars/raw/master/templates/_navbar_wagon.html.erb > app/views/shared/_navbar.html.erb'
-run 'curl -L https://raw.githubusercontent.com/lewagon/rails-templates/master/logo.png > app/assets/images/logo.png'
+# run 'curl -L https://raw.githubusercontent.com/lewagon/rails-templates/master/logo.png > app/assets/images/logo.png'
 
 inject_into_file 'app/views/layouts/application.html.erb', after: '<body>' do
   <<-HTML


### PR DESCRIPTION
The logo in navbar is already hardcode with lewagon url, this comes from the navbar template, you don't need to download the logo to put in the asset/images.

This is not a huge deal, feel free to disregard.