### PR TITLE
Update .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 Style/MissingRespondToMissing:
   Enabled: false
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false


### PR DESCRIPTION
Obsolete configuration found in .rubocop.yml. Updated to current config.