### PR TITLE
Update Clever Cloud templates

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -9,11 +9,13 @@ inject_into_file 'Gemfile', before: 'group :development, :test do' do
     gem 'autoprefixer-rails'
     gem 'font-awesome-sass'
     gem 'simple_form'
+
   RUBY
 end
 
 inject_into_file 'Gemfile', after: 'group :development, :test do' do
   <<-RUBY
+
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'
@@ -24,12 +26,12 @@ gsub_file('Gemfile', /# gem 'redis'/, "gem 'redis'")
 
 # Clevercloud conf file
 ########################################
-file 'clevercloud/ruby.json', <<-EOF
-{
-  "deploy": {
-    "rakegoals": ["assets:precompile", "db:migrate"]
+file 'clevercloud/ruby.json', <<~EOF
+  {
+    "deploy": {
+      "rakegoals": ["assets:precompile", "db:migrate"]
+    }
   }
-}
 EOF
 
 # Database conf file
@@ -102,8 +104,8 @@ end
 
 # README
 ########################################
-markdown_file_content = <<-MARKDOWN
-Rails app generated with [lewagon/rails-templates](https://github.com/lewagon/rails-templates), created by the [Le Wagon coding bootcamp](https://www.lewagon.com) team.
+markdown_file_content = <<~MARKDOWN
+  Rails app generated with [lewagon/rails-templates](https://github.com/lewagon/rails-templates), created by the [Le Wagon coding bootcamp](https://www.lewagon.com) team.
 MARKDOWN
 file 'README.md', markdown_file_content, force: true
 
@@ -115,6 +117,7 @@ generators = <<~RUBY
     generate.helper false
     generate.test_framework :test_unit, fixture: false
   end
+
 RUBY
 
 environment generators
@@ -136,8 +139,10 @@ after_bundle do
   # Git ignore
   ########################################
   append_file '.gitignore', <<~TXT
+
     # Ignore .env file containing credentials.
     .env*
+
     # Ignore Mac and Linux file system files
     *.swp
     .DS_Store

--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -24,6 +24,28 @@ end
 
 gsub_file('Gemfile', /# gem 'redis'/, "gem 'redis'")
 
+# IRB conf file
+########################################
+irbrc = '
+if defined?(Rails)
+  banner = ''
+
+  if Rails.env.production?
+    banner = "\e[41;97;1m prod \e[0m "
+  elsif Rails.env.staging?
+    banner = "\e[43;97;1m staging \e[0m "
+  end
+
+
+  IRB.conf[:PROMPT][:CUSTOM] = IRB.conf[:PROMPT][:DEFAULT].merge(
+    PROMPT_I: "#{banner}#{IRB.conf[:PROMPT][:DEFAULT][:PROMPT_I]}"
+  )
+
+  IRB.conf[:PROMPT_MODE] = :CUSTOM
+end
+'
+file '.irbrc', irbrc.strip
+
 # Clevercloud conf file
 ########################################
 file 'clevercloud/ruby.json', <<~EOF

--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -64,7 +64,9 @@ if Rails.version < "6"
   HTML
   gsub_file('app/views/layouts/application.html.erb', "<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>", scripts)
 end
+
 gsub_file('app/views/layouts/application.html.erb', "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>", "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>")
+
 style = <<~HTML
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
       <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -20,6 +20,28 @@ inject_into_file 'Gemfile', after: 'group :development, :test do' do
   RUBY
 end
 
+# IRB conf file
+########################################
+irbrc = '
+if defined?(Rails)
+  banner = ''
+
+  if Rails.env.production?
+    banner = "\e[41;97;1m prod \e[0m "
+  elsif Rails.env.staging?
+    banner = "\e[43;97;1m staging \e[0m "
+  end
+
+
+  IRB.conf[:PROMPT][:CUSTOM] = IRB.conf[:PROMPT][:DEFAULT].merge(
+    PROMPT_I: "#{banner}#{IRB.conf[:PROMPT][:DEFAULT][:PROMPT_I]}"
+  )
+
+  IRB.conf[:PROMPT_MODE] = :CUSTOM
+end
+'
+file '.irbrc', irbrc.strip
+
 # Clevercloud conf file
 ########################################
 file 'clevercloud/ruby.json', <<~EOF

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -59,11 +59,10 @@ if Rails.version < "6"
         <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   HTML
   gsub_file('app/views/layouts/application.html.erb', "<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>", scripts)
-else
-  gsub_file('app/views/layouts/application.html.erb', "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>", "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>")
 end
 
 gsub_file('app/views/layouts/application.html.erb', "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>", "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>")
+
 style = <<~HTML
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
       <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -22,12 +22,12 @@ end
 
 # Clevercloud conf file
 ########################################
-file 'clevercloud/ruby.json', <<-EOF
-{
-  "deploy": {
-    "rakegoals": ["assets:precompile", "db:migrate"]
+file 'clevercloud/ruby.json', <<~EOF
+  {
+    "deploy": {
+      "rakegoals": ["assets:precompile", "db:migrate"]
+    }
   }
-}
 EOF
 
 # Database conf file
@@ -85,6 +85,7 @@ generators = <<~RUBY
     generate.helper false
     generate.test_framework :test_unit, fixture: false
   end
+
 RUBY
 
 environment generators
@@ -106,6 +107,7 @@ after_bundle do
   # Git ignore
   ########################################
   append_file '.gitignore', <<~TXT
+
     # Ignore .env file containing credentials.
     .env*
 

--- a/devise.rb
+++ b/devise.rb
@@ -42,7 +42,9 @@ if Rails.version < "6"
   HTML
   gsub_file('app/views/layouts/application.html.erb', "<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>", scripts)
 end
+
 gsub_file('app/views/layouts/application.html.erb', "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>", "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>")
+
 style = <<~HTML
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
       <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/minimal.rb
+++ b/minimal.rb
@@ -45,11 +45,10 @@ if Rails.version < "6"
         <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   HTML
   gsub_file('app/views/layouts/application.html.erb', "<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>", scripts)
-else
-  gsub_file('app/views/layouts/application.html.erb', "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>", "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>")
 end
 
 gsub_file('app/views/layouts/application.html.erb', "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>", "<%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>")
+
 style = <<~HTML
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
       <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
## Changes

**Blank Lines**
I added a few blank lines everywhere. 
You might wanna apply them to the regular templates too. If you want them too, I can push an extra commit.

**Javascript snippet (all templates)**
We weren't using the same JS snippet between devise and minimal templates.
I applied devise's one on all templates: both regular and clever cloud.

**IRB conf file**
I added a `.irbrc` config file at the root of the rails project. 
This file displays a banner with the Rails environment.
I configured it only for production and staging environments.

Also, this file is only triggered on production since on localhost, students are using `pry`.

**Goal:** never let a student keep an open connection on the production environment.

<details>
  <summary>Screenshot</summary>
  <img src="https://user-images.githubusercontent.com/50518/105601575-68852a80-5d95-11eb-9ce6-1ff62da6cee4.png" alt="Screenshot of a production rails console with a banner prompt">
</details>

*Note: We've been using it for a few weeks at Fizzer and it's quite pleasant to see this banner.*
*In fact, I've also configured my local pry to always display the env*

Source of inspiration: https://twitter.com/_swanson/status/1346851840944730112
