### PR TITLE
Force bootstrap version 4.6

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -210,7 +210,7 @@ after_bundle do
 
   # Webpacker / Yarn
   ########################################
-  run 'yarn add popper.js jquery bootstrap'
+  run 'yarn add popper.js jquery bootstrap@4.6'
   append_file 'app/javascript/packs/application.js', <<~JS
 
 

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -139,7 +139,7 @@ after_bundle do
 
   # Webpacker / Yarn
   ########################################
-  run 'yarn add popper.js jquery bootstrap'
+  run 'yarn add popper.js jquery bootstrap@4.6'
   append_file 'app/javascript/packs/application.js', <<~JS
 
 

--- a/devise.rb
+++ b/devise.rb
@@ -163,7 +163,7 @@ after_bundle do
 
   # Webpacker / Yarn
   ########################################
-  run 'yarn add popper.js jquery bootstrap'
+  run 'yarn add popper.js jquery bootstrap@4.6'
   append_file 'app/javascript/packs/application.js', <<~JS
 
 

--- a/minimal.rb
+++ b/minimal.rb
@@ -101,7 +101,7 @@ after_bundle do
 
   # Webpacker / Yarn
   ########################################
-  run 'yarn add popper.js jquery bootstrap'
+  run 'yarn add popper.js jquery bootstrap@4.6'
   append_file 'app/javascript/packs/application.js', <<~JS
 
 


### PR DESCRIPTION
Hi 👋,

Following [this conversation](https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1620273620157100) on `#teachers` and while trying to use the LW template myself, I encountered the following issue: Bootstrap has released version 5 🎉 .

However, I don't feel comfortable about releasing the version 5 in our templates without digging a bit more and reading [the release notes](https://blog.getbootstrap.com/2021/05/05/bootstrap-5/) thoroughly. Most of the current bootcamps are past the Front-End module lectures anyway. 

For the time being, I'm forcing Bootstrap version 4.6 when adding the package. 

We can investigate more in a couple of weeks. WDYT?

Thanks 🙏 