### PR TITLE
Force execjs to 2.7

### DIFF
--- a/clever_cloud/devise.rb
+++ b/clever_cloud/devise.rb
@@ -7,6 +7,7 @@ inject_into_file 'Gemfile', before: 'group :development, :test do' do
     gem 'devise'
 
     gem 'autoprefixer-rails'
+    gem 'execjs', '2.7.0'
     gem 'font-awesome-sass'
     gem 'simple_form'
 

--- a/clever_cloud/minimal.rb
+++ b/clever_cloud/minimal.rb
@@ -5,6 +5,7 @@ run "if uname | grep -q 'Darwin'; then pgrep spring | xargs kill -9; fi"
 inject_into_file 'Gemfile', before: 'group :development, :test do' do
   <<~RUBY
     gem 'autoprefixer-rails'
+    gem 'execjs', '2.7.0'
     gem 'font-awesome-sass'
     gem 'simple_form'
 

--- a/devise.rb
+++ b/devise.rb
@@ -7,6 +7,7 @@ inject_into_file 'Gemfile', before: 'group :development, :test do' do
     gem 'devise'
 
     gem 'autoprefixer-rails'
+    gem 'execjs', '2.7.0'
     gem 'font-awesome-sass'
     gem 'simple_form'
   RUBY

--- a/minimal.rb
+++ b/minimal.rb
@@ -5,6 +5,7 @@ run "if uname | grep -q 'Darwin'; then pgrep spring | xargs kill -9; fi"
 inject_into_file 'Gemfile', before: 'group :development, :test do' do
   <<~RUBY
     gem 'autoprefixer-rails'
+    gem 'execjs', '2.7.0'
     gem 'font-awesome-sass'
     gem 'simple_form'
 


### PR DESCRIPTION
The `autoprefixer-rails` gem has a `execjs` dependency. The gem `execjs` just deployed a new version yesterday. Let's force the version of `execjs` to 2.7 while they work on it.

I tested the template and it works. 

I'll create an issue to remember to remove the version once it is compatible again.