### PR TITLE
Prevent transpilling error on Node modules

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -170,6 +170,13 @@ after_bundle do
     import "bootstrap"
   JS
 
+  inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
+    <<~JS
+      // Preventing Babel from transpiling NodeModules packages
+      environment.loaders.delete('nodeModules');
+    JS
+  end
+
   # Dotenv
   ########################################
   run 'touch .env'

--- a/minimal.rb
+++ b/minimal.rb
@@ -110,6 +110,13 @@ after_bundle do
     import "bootstrap"
   JS
 
+  inject_into_file 'config/webpack/environment.js', before: 'module.exports' do
+    <<~JS
+      // Preventing Babel from transpiling NodeModules packages
+      environment.loaders.delete('nodeModules');
+    JS
+  end
+
   # Dotenv
   ########################################
   run 'touch .env'


### PR DESCRIPTION
### Context

Diane had a JS error wile preparing her **Geocoding** for this week
```
An error occurred while parsing the WebWorker bundle. This is most likely due to improper transpilation by Babel;
Uncaught ReferenceError: _createClass is not defined 
```

<img width="636" alt="Capture d’écran 2021-11-15 à 12 26 13" src="https://user-images.githubusercontent.com/11377783/141788976-08a4e4d9-7c8c-4ff8-bec8-e4a547bbbe8d.png">

The problem already happened before [here](https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1553537661132600) or [there](https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1614326147062700?thread_ts=1614107418.038500&cid=G02NFDT0J)

### Solution

This line is present on our templates on [master](https://github.com/lewagon/rails-templates/blob/master/minimal.rb#L130) and should be kept on this branch