### PR TITLE
remove outdated simple form instructions

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -109,9 +109,6 @@ after_bundle do
   generate('simple_form:install', '--bootstrap')
   generate(:controller, 'pages', 'home', '--skip-routes', '--no-test-framework')
 
-  # Replace simple form initializer to work with Bootstrap 5
-  run 'curl -L https://raw.githubusercontent.com/heartcombo/simple_form-bootstrap/main/config/initializers/simple_form_bootstrap.rb > config/initializers/simple_form_bootstrap.rb'
-
   # Routes
   ########################################
   route "root to: 'pages#home'"

--- a/minimal.rb
+++ b/minimal.rb
@@ -84,9 +84,6 @@ after_bundle do
   generate('simple_form:install', '--bootstrap')
   generate(:controller, 'pages', 'home', '--skip-routes', '--no-test-framework')
 
-  # Replace simple form initializer to work with Bootstrap 5
-  run 'curl -L https://raw.githubusercontent.com/heartcombo/simple_form-bootstrap/main/config/initializers/simple_form_bootstrap.rb > config/initializers/simple_form_bootstrap.rb'
-
   # Routes
   ########################################
   route "root to: 'pages#home'"


### PR DESCRIPTION
Fixes #139

Now that the[ initializer](https://github.com/heartcombo/simple_form/blob/main/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb) of Simple Form comes with the updated code for Bootstrap 5 we can remove the extra instructions in the lectures and templates 🙌