### PR TITLE
Fix popper import in application.js

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -177,7 +177,7 @@ after_bundle do
   run "importmap pin bootstrap"
 
   append_file "app/javascript/application.js", <<~JS
-    import "popper"
+    import "@popperjs/core"
     import "bootstrap"
   JS
 

--- a/minimal.rb
+++ b/minimal.rb
@@ -94,7 +94,7 @@ after_bundle do
   run "importmap pin bootstrap"
 
   append_file "app/javascript/application.js", <<~JS
-    import "popper"
+    import "@popperjs/core"
     import "bootstrap"
   JS
 


### PR DESCRIPTION
During the recording of the `javascript-in-rails` lecture I noticed that popper wasn't properly imported in the `application.js` file (which was erroring all the js execution).

Fixed it by replacing `import "popper"` by `import "@popperjs/core"` 👌 