### PR TITLE
minimal.rb gets contents from rails-stylesheets master branch

### DIFF
--- a/minimal.rb
+++ b/minimal.rb
@@ -22,9 +22,9 @@ gsub_file("Gemfile", '# gem "sassc-rails"', 'gem "sassc-rails"')
 ########################################
 run "rm -rf app/assets/stylesheets"
 run "rm -rf vendor"
-run "curl -L https://github.com/lewagon/rails-stylesheets/archive/more-js.zip > stylesheets.zip"
-run "unzip stylesheets.zip -d app/assets && rm -f stylesheets.zip && rm -f app/assets/rails-stylesheets-more-js/README.md"
-run "mv app/assets/rails-stylesheets-more-js app/assets/stylesheets"
+run "curl -L https://github.com/lewagon/rails-stylesheets/archive/master.zip > stylesheets.zip"
+run "unzip stylesheets.zip -d app/assets && rm -f stylesheets.zip && rm -f app/assets/rails-stylesheets-master/README.md"
+run "mv app/assets/rails-stylesheets-master app/assets/stylesheets"
 
 # Layout
 ########################################


### PR DESCRIPTION
The `more-js` doesn't exist anymore and is making the template crash the `rails new` process.

Closes #154