### PR TITLE
Update `inject_into_file` `dotenv-rails` gem to avoid confusions with platforms

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -14,7 +14,7 @@ inject_into_file "Gemfile", before: "group :development, :test do" do
   RUBY
 end
 
-inject_into_file "Gemfile", after: 'gem "debug", platforms: %i[ mri mingw x64_mingw ]' do
+inject_into_file "Gemfile", after: "group :development, :test do" do
   "\n  gem \"dotenv-rails\""
 end
 

--- a/minimal.rb
+++ b/minimal.rb
@@ -13,7 +13,7 @@ inject_into_file "Gemfile", before: "group :development, :test do" do
   RUBY
 end
 
-inject_into_file "Gemfile", after: 'gem "debug", platforms: %i[ mri mingw x64_mingw ]' do
+inject_into_file "Gemfile", after: "group :development, :test do" do
   "\n  gem \"dotenv-rails\""
 end
 


### PR DESCRIPTION
Cf [this thread in #teachers](https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1700307051079839)

The `dotenv-rails` gem was not being added in some cases as the debug line can be added when creating the rails app with different platform names:

- On my laptop: `gem "debug", platforms: %i[ mri mingw x64_mingw ]`
- On ElvisDot's laptop: `gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ]`

Using the `group :development, :test do` instead to inject the gem 👌 

Now using the updated minimal template, the `dotenv-rails` gem file still gets added properly 👇 

![image](https://github.com/lewagon/rails-templates/assets/57643651/131f2ca8-841d-41e6-854d-2f9e6b279207)

