### PR TITLE
Turn off raise_on_missing_callback_actions

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -82,6 +82,14 @@ RUBY
 
 environment generators
 
+# General Config
+########################################
+general_config = <<~RUBY
+config.action_controller.raise_on_missing_callback_actions = false
+RUBY
+
+environment general_config
+
 ########################################
 # After bundle
 ########################################

--- a/minimal.rb
+++ b/minimal.rb
@@ -54,6 +54,14 @@ RUBY
 
 environment generators
 
+# General Config
+########################################
+general_config = <<~RUBY
+config.action_controller.raise_on_missing_callback_actions = false
+RUBY
+
+environment general_config
+
 ########################################
 # After bundle
 ########################################


### PR DESCRIPTION
resolve https://github.com/lewagon/teachers/issues/2420

According to [this article](https://www.shakacode.com/blog/rails-adds-ability-to-raise-error-on-missing-callback-actions/), this feature is just to prevent typos. But in our case, it's breaking our Pundit setup in prod, so I think it's better to just turn it off.