### PR TITLE
Turn off raise on missing controller on older Rails versions

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -85,7 +85,7 @@ environment generators
 # General Config
 ########################################
 general_config = <<~RUBY
-config.action_controller.raise_on_missing_callback_actions = false
+  config.action_controller.raise_on_missing_callback_actions = false if Rails.version >= "7.1.0"
 RUBY
 
 environment general_config

--- a/minimal.rb
+++ b/minimal.rb
@@ -57,7 +57,7 @@ environment generators
 # General Config
 ########################################
 general_config = <<~RUBY
-config.action_controller.raise_on_missing_callback_actions = false
+  config.action_controller.raise_on_missing_callback_actions = false if Rails.version >= "7.1.0"
 RUBY
 
 environment general_config


### PR DESCRIPTION
For people with 7.0, this was breaking the template, even though it works totally fine on 7.1.