### PR TITLE
Add hotwire-livereload

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -18,6 +18,10 @@ inject_into_file "Gemfile", after: "group :development, :test do" do
   "\n  gem \"dotenv-rails\""
 end
 
+inject_into_file "Gemfile", after: "group :development do" do
+  "\n  gem \"hotwire-livereload\""
+end
+
 # Assets
 ########################################
 run "rm -rf app/assets/stylesheets"
@@ -194,6 +198,10 @@ after_bundle do
   # Rubocop
   ########################################
   run "curl -L https://raw.githubusercontent.com/lewagon/rails-templates/master/.rubocop.yml > .rubocop.yml"
+
+  # Live refresh
+  ########################################
+  run "rails livereload:install"
 
   # Git
   ########################################

--- a/minimal.rb
+++ b/minimal.rb
@@ -17,6 +17,10 @@ inject_into_file "Gemfile", after: "group :development, :test do" do
   "\n  gem \"dotenv-rails\""
 end
 
+inject_into_file "Gemfile", after: "group :development do" do
+  "\n  gem \"hotwire-livereload\""
+end
+
 # Assets
 ########################################
 run "rm -rf app/assets/stylesheets"
@@ -119,6 +123,10 @@ after_bundle do
   # Rubocop
   ########################################
   run "curl -L https://raw.githubusercontent.com/lewagon/rails-templates/master/.rubocop.yml > .rubocop.yml"
+
+  # Live refresh
+  ########################################
+  run "rails livereload:install"
 
   # Git
   ########################################


### PR DESCRIPTION
This is _optional_ and I would totally understand if we reject it because we don't want to add another dependency.

But this PR would add livereload functionality to our Rails templates. I've just tested it and it works almost instantly for CSS and JS changes. This is a feature that we used to have for JS with Webpack but lost with the new importmap setup. We've actually never had it for CSS, so it's even fancier than before (yay!).

I thought it would be a nice thing to include since it could speed up development for students during project weeks and also help with teachers doing CSS changes in lectures.

I'm honestly not sure we need to explain this to students, but if we wanted to, I could add it into our "front-end setup" guide, which is done in some livecodes, or into the Rails Assets lecture. But I think it's such a simple change (literally adding one gem and running a Terminal command) that it's almost not worth the airtime.

Related:
- https://github.com/lewagon/karr/pull/1043